### PR TITLE
Allow SOAP requests where method/parameter naming conventions don't follow the GSX Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ some performance benefits by minimizing the number of requests made to the serve
 validation (as opposed to burdening Apple's servers with totally invalid requests).
 
 
-Requrements
+Requirements
 ===========
 
 - SOAP support in your PHP

--- a/gsxlib.php
+++ b/gsxlib.php
@@ -569,17 +569,23 @@ class GsxLib
     
     /**
     * Do the actual SOAP request
+	* alt_req_name and alt_resp_name are only necessary when the GSX WSDL
+	* does not match the standard MethodName, MethodNameRequest, MethodNameResponse
+	* format that most of the WSDL conforms to.
     */
-    public function request($req)
+    public function request($req,$alt_req_name="",$alt_resp_name="")
     {
         $result = FALSE;
 
         // split the request name and data
         list($r, $p) = each($req);
+		//handle alternate request name
+		$request_name = $alt_req_name ? $alt_req_name : $r . "Request";
+		$response_name = $alt_resp_name ? $alt_resp_name : $r . "Response";
 
         // add session info
         $p['userSession'] = array('userSessionId' => $this->session_id);
-        $request = array($r.'Request' => $p);
+        $request = array($request_name => $p);
 
         try {
             $result = $this->client->$r($request);
@@ -589,7 +595,7 @@ class GsxLib
                 syslog(LOG_NOTICE, "REQUEST: \n" . $this->client->__getLastRequest());
                 syslog(LOG_NOTICE, "RESPONSE: \n" . $this->client->__getLastResponse());
             }
-            return $result->$resp;
+            return $result->$response_name;
         } catch(SoapFault $e) {
             throw new GsxException($e->getMessage(), $this->client->__getLastRequest());
         }


### PR DESCRIPTION
Most methods in the GSX WSDL conform to the following format:
```
		method: MethodName
		request: MethodNameRequest
		response: MethodNameResponse
```
For those methods that are defined in this format, no additional specifiers are needed. For all others, a custom request and response name can be crafted. A specific example is:
```
		method: FetchDiagnosticSuites
		request: FetchDiagnosticSuitesRequestData
		response: FetchDiagnosticSuitesResponseData
```
Note the inclusion of a seemingly random "Data" tacked on the end.. This causes the SOAP request to fail because the standard method of tacking "Request" and "Response" onto the end of the method name does not result in valid parameters.
The exceptions are few and far between but if your GSX Request does not function as expected, and you've triple-checked that you're providing the right parameters, this is probably why.


This is backwards compatible and does not affect existing implementations of GSXLib.
Additionally, I fixed a typo in the readme.